### PR TITLE
Allow user to authenticate with github via personal access token

### DIFF
--- a/github.go
+++ b/github.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-github/github"
 	"github.com/hashicorp/go-version"
+	"golang.org/x/oauth2"
 )
 
 // FixVersionStrFunc is function to fix version string
@@ -92,6 +93,14 @@ func DeleteFrontV() FixVersionStrFunc {
 
 func (g *GithubTag) newClient() *github.Client {
 	client := github.NewClient(nil)
+	if g.Token != "" {
+		ctx := context.Background()
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: g.Token},
+		)
+		tc := oauth2.NewClient(ctx, ts)
+		client = github.NewClient(tc)
+	}
 	if g.URL != "" {
 		client.BaseURL, _ = url.Parse(g.URL)
 	}


### PR DESCRIPTION
`GithubTag` already had a `Token` member that seemed to have to do with allowing authentication to the repo.  Use this to provide a personal access token and list the repo's tags using a static oauth authenticated client.  See https://github.com/google/go-github#user-content-authentication.